### PR TITLE
add minimum cmake configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-
+build/**
 *.user
+**/*.swp
+output/*.dat
+output/*.csv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.15)
+include_guard(GLOBAL)
+
+project(batotp)
+
+option(BUILD_EXAMPLES "Build example programs" ON)
+
+add_subdirectory(batotp)
+
+if (BUILD_EXAMPLES)
+  add_subdirectory(test)
+endif()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A bisection algorithm for time-optimal trajectory planning along fully specified paths
 
 
-1. Description --------------------------------------------------
+## Description
 
 This repository contains C++ source code for BA, a bisection algorithm for time-optimal trajectory planning along fully specified paths. A detailed description of the algorithm is provided in the following article:
 
@@ -16,12 +16,12 @@ The source code is divided into two main subprojects:
 
 Many configuration parameters can be set by using the input/config.dat file. Additional customization can be accomplished by modifying the batest subproject (test/main.cpp). For example, output data files are not needed for all applications. Finally, the BA algorithm can be readily integrated into other projects by linking the batotp library.
 
-2. License --------------------------------------------------
+## License 
 
 The source code for BA is subject to the terms of the Berkeley Software Distribution (BSD) 3-clause license. A copy of the BSD license is contained in the LICENSE file. If a copy of the BSD license was not distributed with this file, you can obtain one at
 https://opensource.org/licenses/BSD-3-Clause.
 
-3. Compiling BA --------------------------------------------------
+## Compiling BA 
 
 BA has been written to be compatible with the C++11 standard. Two commonly used compilers that are compatible with this standard are:
 - gcc, version 4.8.1 or later
@@ -36,9 +36,9 @@ Two precompiled binaries are included in the Release folder. These can be used d
 - bin/batest     for 64-bit Linux   (compiled in Ubuntu 16.04)
 - bin/x64/batest.exe for 64-bit Windows (compiled in Windows 7)
 
-3.1 Linux (tested on Ubuntu 16.04 LTS 64-bit)
+### Linux (tested on Ubuntu 16.04 LTS 64-bit)
 
-3.1.1. Configure Eigen:
+#### Configure Eigen:
 - Download the .tar.gz archive file for latest stable release of Eigen (Eigen 3.3.4 at the time this README was written) from http://eigen.tuxfamily.org
 -  Extract the archive.
 -  Open the extracted folder. Follow the instructions in the INSTALL file. Since Eigen is a header template library, there are no libraries to link. 
@@ -49,9 +49,9 @@ If this does not work for some reason, you can copy the Eigen folder to one of t
   /PathToParentFolder/time_optimal_trajectory_planning/batotp
   /PathToParentFolder/eigenlib/Eigen
 
-3.1.2. Verify the version of the gcc compiler (In Ubuntu the command for this is "gcc -v". BA was tested using gcc 5.4.1, but versions 4.8.1 and up should work.
+#### Verify the version of the gcc compiler (In Ubuntu the command for this is "gcc -v". BA was tested using gcc 5.4.1, but versions 4.8.1 and up should work.
 
-3.1.3. Compile BA
+#### Compile BA
 
 a. Using only the gcc compiler
 - Open a terminal in the folder that BA was extracted to, which should include the file compile.sh
@@ -68,9 +68,9 @@ https://download.qt.io/archive/qt/5.10/5.10.0/qt-opensource-linux-x64-5.10.0.run
 - You can run the executable in Qt using the keystroke "CTRL + R", or you can run it separately in another terminal
 
 
-3.2 Windows (tested on Windows 7 Pro 64-bit)
+### Windows (tested on Windows 7 Pro 64-bit)
 
-3.2.1. Configure Eigen:
+#### Configure Eigen:
 - Download the .zip archive file for latest stable release of Eigen (Eigen 3.3.4 at the time this README was written) from http://eigen.tuxfamily.org
 -  Extract the archive.
 -  Open the extracted folder. The necessary source files are all in the Eigen folder. Since Eigen is a header template library, there are no libraries to link.
@@ -78,7 +78,7 @@ https://download.qt.io/archive/qt/5.10/5.10.0/qt-opensource-linux-x64-5.10.0.run
   /PathToParentFolder/time_optimal_trajectory_planning/batotp
   /PathToParentFolder/eigenlib/Eigen
 
-3.2.2. Compile BA
+#### Compile BA
   
 a. Using MinGW
 - Download and install MinGW:
@@ -110,12 +110,40 @@ For Visual Studio 2017 Community, during installation, select the option "Deskto
 - Click on the top menu item Build, then Build Solution
 - The executable is batest.exe, and it will be located in the Debug or Release folder (these are subfolders of the x64 folder for 64-bit builds)
 
+### CMake
 
-4. Using BA --------------------------------------------------
+From the root directory:
+
+Create a directory for the build files:
+
+```
+mkdir build 
+```
+
+Execute CMake:
+
+```
+cd build
+cmake ..
+```
+
+Build the library:
+
+```
+make -j8
+```
+
+Execute the provided example:
+
+```
+./test/batotp_test
+```
+
+## Using BA
 
 Three methods for using BA are described below.
 
-4.1 The bin/batest executable (bin/batest.exe in Windows) and config.dat
+### The bin/batest executable (bin/batest.exe in Windows) and config.dat
 
 The executable can be run from the terminal (command prompt in Windows), or from an .sh script (.bat file in Windows). It can also be called from any software that can issue system commands, such as MATLAB.
 
@@ -123,15 +151,15 @@ Options are specified in the file "../input/config.dat", where the folder locati
 
 After running the executable, the output trajectory data file, along with other output files related to algorithm performance, can be found in the "output" folder.
 
-4.2 Command line options
+### Command line options
 
 A different configuration file can be specified as a command line option. For example, for the input file "configRR.dat", the command is "batest configRR.dat". In this case, all output files will be generated in the same folder as the batest executable. 
 
-4.3 The batotp library
+### The batotp library
 
 To integrate BA into other projects, functions can be linked directly from the batotp library. The test subproject which generates the batest executable provides a demonstration of how this is accomplished.
 
-5. Examples --------------------------------------------------
+## Examples 
 
 Five examples can be found in the input folder, which correspond to the five robots defined in robot.cpp:
 
@@ -152,13 +180,13 @@ All .m scripts were tested using Octave 4.2.1. Note that in Windows 7, the first
 Older versions of Ubuntu (e.g. 14.04) might install an older version of Octave by default. To install a newer version, the instructions at the following webpage can be adapted:
 https://askubuntu.com/questions/645600/how-to-install-octave-4-0-0-in-ubuntu-14-04
 
-5.1 A general 7-DOF serial robot, without a kinematic or dynamic model
+### A general 7-DOF serial robot, without a kinematic or dynamic model
 
 - Joint positions can be thought of as unit-less, though for this example, reasonable values for radians are chosen
 - Constraints are imposed on joint velocity and joint acceleration
 - When joint positions have units, constraints must be specified in consistent units in the config.dat file. In this case, reasonable limits in radians of 5 rad/s for velocity and 10 rad/s^2 for acceleration are chosen for each joint.
 
-5.1.1 Generating trajectory data
+#### Generating trajectory data
 
 Two methods for generating trajectory data are provided:
 
@@ -168,11 +196,11 @@ generateGEN7DOFpath.m - Generates 20 random traj. points, then uses spline inter
 
 The config.dat file specifies "GEN7DOFpathBasic.csv" as the traj. data file, so in order to run this example, both config.dat and GEN7DOFpathBasic.csv must be copied to the input folder.
 
-5.1.2 Executing batest / Running the optimization
+#### Executing batest / Running the optimization
 Ubuntu: Open a terminal in the Release or Debug folder. Run "./batest".
 Windows: Open a command prompt in the Release or Debug folder. Run "batest.exe".
 
-5.1.3 Viewing the output trajectory and algorithm performance
+#### Viewing the output trajectory and algorithm performance
 - Open Octave or Matlab in the output folder.
 - Run plotOutput.m
 - Plots are generated of:
@@ -180,18 +208,18 @@ Windows: Open a command prompt in the Release or Debug folder. Run "batest.exe".
   - Fig. 3(a): Output joint velocity vs. time
   - Fig. 3(b): Output joint accel.   vs. time
 
-5.2 A 3-DOF cable-suspended parallel mechanism (CSPR), with kinematic and dynamic constraints
+### A 3-DOF cable-suspended parallel mechanism (CSPR), with kinematic and dynamic constraints
 - Position data are specified as (x,y,z) coordinates in metres
 - Constraints are imposed on joint velocity (cable velocity), joint acceleration (cable acceleration), Cartesian speed, and cable tension
 
-5.2.1 Generating the trajectory data
+#### Generating the trajectory data
 Open and run the file "input/CSPR3DOF/generatePathPointsCSPR.m" in Octave or Matlab. The binary trajectory data file "CSPR3DOFspline.dat" will be generated. Copy "config.dat" and "CSPR3DOFspline.dat" to the input folder.
 
-5.2.2 Executing batest / Running the optimization
+#### Executing batest / Running the optimization
 Ubuntu: Open a terminal in the Release or Debug folder. Run "./batest".
 Windows: Open a command prompt in the Release or Debug folder. Run "batest.exe"
 
-5.2.3 Viewing the output trajectory and algorithm performance
+#### Viewing the output trajectory and algorithm performance
 - Open Octave or Matlab in the output folder.
 - Run plotOutput.m
 - Plots are generated of:
@@ -203,7 +231,7 @@ Windows: Open a command prompt in the Release or Debug folder. Run "batest.exe"
   - Fig. 4(b): Output Cartesian accel. vs. time
   - Fig. 5: Output Cable tension vs. time
 
-6. Defining new robots for BA --------------------------------------------------
+## Defining new robots for BA 
 
 The easiest way to use a new robot in BA is to add it to robots.cpp. There, kinematics and dynamics functions for other robots are provided, which can be used as starting points.
 

--- a/batotp/CMakeLists.txt
+++ b/batotp/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.15)
+include_guard(GLOBAL)
+
+project(batotp_lib) 
+
+find_package(Eigen3 REQUIRED)
+
+add_library(${PROJECT_NAME} STATIC)
+
+target_sources(${PROJECT_NAME} PRIVATE
+  ba.cpp
+  robot.cpp
+  spline.cpp
+  util.cpp
+)
+
+add_library(${PROJECT_NAME}_if INTERFACE)
+
+target_sources(${PROJECT_NAME}_if INTERFACE
+  ba.h
+  config.h
+  robot.h
+  spline.h
+  util.h
+)
+
+target_include_directories(${PROJECT_NAME}_if INTERFACE .)
+target_link_libraries(${PROJECT_NAME}_if INTERFACE Eigen3::Eigen)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${PROJECT_NAME}_if
+)

--- a/batotp/util.h
+++ b/batotp/util.h
@@ -40,6 +40,8 @@
 #include <algorithm> // std::min
 #include <functional> // transform,bind1st
 #include <cmath>
+#include <cstdio>
+#include <string>
 
 struct Time
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+include_guard(GLOBAL)
+
+project(batotp_test) 
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} batotp_lib)


### PR DESCRIPTION
Hi. First of all, thanks for the amazing paper! Just adding the possibility to build the library with cmake. May be of interest for someone who wants to test it without installing any extra software and is also easier for integrating batotp as a standalone library into another project. Also changed some things in the README to make it more markdown style and added some missing includes. Without them I couldn't compile the code on my PC. 